### PR TITLE
Add simple command-line chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ If you care about Application Security and want to collaborate with the key play
 The Summit will occur in England, 12-16 June 2017, with an entry ticket of 1400 EUR + VAT (covering stay + accommodation + event fee). OWASP has somefunding for its leaders and other deserving individuals to attend, so if you feel you can't afford this fee, or your company is not in a position to sponsor you, please contact the event organisers.
 
 If you want to be involved, add you name to the [Participants](Participants) page
+
+## Chatbot
+
+A simple command-line chatbot is included for demonstration. Run it with:
+
+```bash
+npm run chatbot
+```
+
+Type `bye` to exit the conversation.

--- a/chatbot.js
+++ b/chatbot.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+const readline = require('readline');
+
+const responses = {
+  hello: 'Hello! How can I help you?',
+  hi: 'Hi there! How can I assist?',
+  bye: 'Goodbye!',
+  help: 'I am a simple chatbot. Try saying hello.'
+};
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+const ask = () => {
+  rl.question('You: ', (input) => {
+    const key = input.trim().toLowerCase();
+    const response = responses[key] || "I'm sorry, I don't understand.";
+    console.log(`Bot: ${response}`);
+    if (key === 'bye') {
+      rl.close();
+    } else {
+      ask();
+    }
+  });
+};
+
+console.log('Chatbot started. Type "bye" to exit.');
+ask();

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build-data": "coffee ./src/server/build-data.coffee",
     "test": "node ./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register --recursive -R list src/server/test",
     "test-watch": "npm test -- --watch",
-    "start": "coffee src/server/main.coffee"
-
+    "start": "coffee src/server/main.coffee",
+    "chatbot": "node chatbot.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add `chatbot.js` implementing a small command-line chatbot
- expose `npm run chatbot` in `package.json`
- document chatbot usage in `README.md`

## Testing
- `npm test` *(fails: Jekyll_Data tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68441d626818832e961f106c41a477c4